### PR TITLE
Restrict image size prior to making edits and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fill-color for hex color codes now supports 3-,4-,6-, and 8-digit formats
+- incoming image size limitations can now be configured and enforced with environment variables, preventing large images
+from timing out
 
 ## [2.0.1] - 2020-01-09
 

--- a/settings.example.yml
+++ b/settings.example.yml
@@ -6,6 +6,8 @@ defaults: &defaults
     DEFAULT_QUALITY: 75
     DEFAULT_COMPRESS_QUALITY: 45
     SLS_IGNORE: favicon.ico
+    MAX_IMAGE_WIDTH: 2000
+    MAX_IMAGE_HEIGHT: 1000
 
 stages:
   dev:

--- a/src/ImageHandler.js
+++ b/src/ImageHandler.js
@@ -86,6 +86,7 @@ class ImageHandler {
    */
   async applyEdits (originalImage, edits) {
     const image = sharp(originalImage)
+    await imageOps.restrictSize(image, await image.metadata())
     await imageOps.apply(image, edits)
     return image
   }

--- a/src/image-ops/index.js
+++ b/src/image-ops/index.js
@@ -28,3 +28,14 @@ exports.apply = async (image, edits) => {
     }
   }
 }
+
+exports.restrictSize = async (image, metadata) => {
+  const maxImgWidth = process.env.MAX_IMAGE_WIDTH !== null ? parseInt(process.env.MAX_IMAGE_WIDTH) : null;
+  const maxImgHeight = process.env.MAX_IMAGE_HEIGHT !== null ? parseInt(process.env.MAX_IMAGE_HEIGHT) : null;
+  if ((maxImgWidth && metadata.width > maxImgWidth) || (maxImgHeight && metadata.height > maxImgHeight)) {
+    const aspectRatio = parseFloat(metadata.width) / metadata.height
+    const width = aspectRatio >= 1 ? maxImgWidth : null,
+        height = width === null ? maxImgHeight : null
+    await size.scaleMax(image, width, height)
+  }
+}


### PR DESCRIPTION
Allows very large images to be processed much faster in order to avoid any potential timeout issues

https://github.com/venveo/serverless-sharp/issues/37