### PR TITLE
Add custom domain and certificate for the cloudfront distribution.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -24,6 +24,8 @@ layers:
     retain: false
 
 resources:
+  Conditions: 
+    CreateCertificate: !Not [!Equals ["${self:custom.settings.environment.CUSTOM_DOMAIN, ''}", ""]]
   Resources:
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
@@ -51,7 +53,25 @@ resources:
                 HTTPPort: 80
                 HTTPSPort: 443
                 OriginProtocolPolicy: https-only
-
+          Aliases:
+            Fn::If:
+            - CreateCertificate
+            - - '${self:custom.settings.environment.CUSTOM_DOMAIN, self:custom.empty}'
+            - Ref: AWS::NoValue
+          ViewerCertificate:
+            Fn::If:
+            - CreateCertificate
+            - AcmCertificateArn:
+                Ref: Certificate
+              SslSupportMethod: 'sni-only'
+              MinimumProtocolVersion: 'TLSv1'
+            - Ref: AWS::NoValue
+    Certificate:
+      Type: AWS::CertificateManager::Certificate
+      Condition: CreateCertificate
+      Properties:
+        DomainName: '${self:custom.settings.environment.CUSTOM_DOMAIN}'
+        ValidationMethod: DNS
 functions:
   index:
     handler: src/index.handler
@@ -68,6 +88,7 @@ Outputs:
     Value:
       'Fn::GetAtt': [ CloudFrontDistribution, DomainName ]
 custom:
+  empty: ''
   settingsFilePath: ${opt:settings,'./settings.yml'}
   settings: ${file(${self:custom.settingsFilePath}):stages.${self:provider.stage}}
   serverless-offline:

--- a/settings.example.yml
+++ b/settings.example.yml
@@ -17,9 +17,11 @@ stages:
       <<: *defaults.environment
       SOURCE_BUCKET: 'my-bucket/prefix/path'
       SECURITY_KEY: ''
+      CUSTOM_DOMAIN: ''
   prod:
     <<: *defaults
     environment:
       <<: *defaults.environment
       SOURCE_BUCKET: 'random-string-here'
       SECURITY_KEY: ''
+      CUSTOM_DOMAIN: 'my.domain.com'


### PR DESCRIPTION
Here's a PR to optionally add a custom domain to the CF distribution.  Certificate will be authenticated by DNS.