### PR TITLE
302 Not Modified / Last- Modified Header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,12 @@ exports.handler = async (event, context, callback) => {
  * @param {boolean} isErr - has an error been thrown?
  */
 const getResponseHeaders = (processedRequest, isErr) => {
+  const timenow = new Date()
   const headers = {
     'Access-Control-Allow-Methods': 'GET',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    'Access-Control-Allow-Credentials': true
+    'Access-Control-Allow-Credentials': true,
+    'Last-Modified': timenow.toString()
   }
   const cacheControlDefault = settings.getSetting('DEFAULT_CACHE_CONTROL')
   if (processedRequest) {


### PR DESCRIPTION
By setting a Last-Modified Timestamp, AWS Api Gateway / Cloudfront will automatically return a 304 Not Modified status code on cache hit, allowing browsers and mobile devices to client side cache, server side cached content.  Closes #69.