### PR TITLE
fix/pass-through

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,13 @@ exports.handler = async (event, context, callback) => {
         body: imageRequest.originalImageBody.toString('utf8'),
         isBase64Encoded: false
       }
+      if(imageRequest.key.match(/(.css)$/)){
+        response.headers['Content-Type'] = 'text/css'
+      }else if (imageRequest.key.match(/(.js)$/)){
+        response.headers['Content-Type'] = 'text/javascript'
+      }else if (imageRequest.key.match(/(.html)$/)){
+        response.headers['Content-Type'] = 'text/html'
+      }
     }
     context.succeed(response)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,10 @@ exports.handler = async (event, context, callback) => {
     context.succeed(beforeHandle.response)
     return
   }
+  let imageRequest = null
 
   try {
-    const imageRequest = new ImageRequest(event)
+    imageRequest = new ImageRequest(event)
     await imageRequest.process() // This is important! We need to load the metadata off the image and check the format
     const imageHandler = new ImageHandler(imageRequest)
 
@@ -27,11 +28,19 @@ exports.handler = async (event, context, callback) => {
     }
     context.succeed(response)
   } catch (err) {
-    const response = {
+    let response = {
       statusCode: err.status,
       headers: getResponseHeaders(null, true),
       body: JSON.stringify(err),
       isBase64Encoded: false
+    }
+    if(imageRequest && imageRequest.originalImageBody){
+      response = {
+        statusCode: 200,
+        headers: getResponseHeaders(null, true),
+        body: imageRequest.originalImageBody.toString('utf8'),
+        isBase64Encoded: false
+      }
     }
     context.succeed(response)
   }


### PR DESCRIPTION
Non-image content - including HTML, javascript and css - currently returns a 403 error with an empty hash.  The expected behavior is that non-image requests should return the original file content as utf8.  The benefit of this approach is that serverless-sharp can be mounted on a function path, say ‘/public’, and serve all static asset content from an S3 Bucket!