### PR TITLE
serverless-http / koa middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,9 @@ exports.handler = async (event, context, callback) => {
   const beforeHandle = beforeHandleRequest(event)
 
   if (!beforeHandle.allowed) {
-    context.succeed(beforeHandle.response)
-    return
+    if(context && context.succeed)
+      context.succeed(beforeHandle.response)
+    return beforeHandle.response
   }
 
   try {
@@ -25,7 +26,9 @@ exports.handler = async (event, context, callback) => {
       body: processedRequest.Body,
       isBase64Encoded: true
     }
-    context.succeed(response)
+    if(context && context.succeed)
+      context.succeed(response)
+    return response
   } catch (err) {
     const response = {
       statusCode: err.status,
@@ -33,7 +36,9 @@ exports.handler = async (event, context, callback) => {
       body: JSON.stringify(err),
       isBase64Encoded: false
     }
-    context.succeed(response)
+    if(context && context.succeed)
+      context.succeed(response)
+    return response
   }
 }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,38 @@
+/**
+ * serverless-http koa middleware example
+ */
+
+'use strict';
+
+const fs = require('fs')
+const serverless = require('serverless-http');
+const Koa = require('koa');
+
+const { handler } = require('./index') 
+// Or ./node_modules/serverless-sharp/src/index
+
+const app = new Koa();
+
+app.use(async(ctx,next) => {
+
+  /**
+  * handler
+  * @param {string} path
+  * @param {hash} headers
+  * @param {hash} queryStringParameters
+  **/
+
+  const result = await handler({
+    path: ctx.path,
+    headers: ctx.header,
+    queryStringParameters: {...ctx.request.query}
+  })
+
+  if(result.body){
+    ctx.set(result.headers)
+    ctx.status = result.statusCode
+    ctx.body = new Buffer(result.body, 'base64')
+    await next();
+  }
+});
+module.exports.handler  = serverless(app, {binary: ['*/*']});


### PR DESCRIPTION
The src/index.js handler function should return a response - after using the context success callback, if present - so that handler function can be used as async middleware.

An example middleware handler (src/middleware.js) details how to use serverless-sharp in a serverless-http, koa middleware stack.  The src/middleware.js example requires  serverless-http and koa.  Note:  koa *requires* a binary buffer body.

Closes #73. Resolves the need for #72, as additional error and content type handling can now be handled further down the middleware stack.  