### PR TITLE
apiGateway binaryMediaTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-sharp",
-  "version": "2.0.3",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11379,21 +11379,6 @@
             "decamelize": "^1.2.0"
           }
         }
-      }
-    },
-    "serverless-apigw-binary": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/serverless-apigw-binary/-/serverless-apigw-binary-0.4.4.tgz",
-      "integrity": "sha512-2DJmQTzeXa/+8u9ekReqf7j4gQjBtzQE4MK9nlOnEz4F7MVWCQXYlLPmf2TXSoxxJZzlWvIiNzCTq6vAT9F5FQ==",
-      "dev": true
-    },
-    "serverless-apigwy-binary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/serverless-apigwy-binary/-/serverless-apigwy-binary-1.0.0.tgz",
-      "integrity": "sha512-nr2fDkGRk6/PioE5l6Dk5anYmrN4pdjoT4eHxr+RGIn+ZRJcYDlNBB6ytVRvSAL2txkkNd44HA/hKSGbHQw96Q==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0"
       }
     },
     "serverless-offline": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "aws-sdk-mock": "^5.1.0",
     "jest": "^26.0.1",
     "serverless": "^1.69.0",
-    "serverless-apigw-binary": "^0.4.4",
-    "serverless-apigwy-binary": "^1.0.0",
     "serverless-offline": "^6.1.5",
     "sharp": "0.25.2",
     "standard": "^14.3.3"

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,9 @@ provider:
       Action:
         - "s3:GetObject"
       Resource: "arn:aws:s3:::${self:custom.settings.environment.SOURCE_BUCKET}/*"
+  apiGateway:
+    binaryMediaTypes:
+      - '*/*'
 
 layers:
   sharp:
@@ -105,10 +108,6 @@ custom:
   serverless-offline:
     httpPort: ${self:custom.settings.offlinePort}
     noPrependStageInUrl: true
-  apigwBinary:
-    types:
-      - '*/*'
+
 plugins:
   - serverless-offline
-  - serverless-apigw-binary
-  - serverless-apigwy-binary


### PR DESCRIPTION
The `serverless-apiw-binary` and `serverless-apigwy-binary` plugins aren’t required when using apiGateway binaryMediaTypes. This PR removes the unneeded dependencies.

```
provider:
  apiGateway:
    binaryMediaTypes:
      - '*/*'
```