### PR TITLE
Sharp does not support text overlays

### DIFF
--- a/src/helpers/schemaParser.js
+++ b/src/helpers/schemaParser.js
@@ -360,6 +360,11 @@ exports.processExpectation = (expects = {}, value) => {
       result.processedValue = value
       result.passed = true
       return result
+    case 'font':
+      // TODO:
+      result.processedValue = value
+      result.passed = true
+      return result
     // throw new ExpectationTypeException;
     default:
       console.error('Encountered unknown expectation type: ' + expects.type)


### PR DESCRIPTION
If a legacy imgix image url includes text overlay (using txtfont) serverless-sharp generates an error and renders a broken image, instead of ignoring the unsupported param, which would be the preferred outcome.

This pull request adds the ‘font’ processExpectation switch and returns the processed image - ignoring the text params - allowing the app to fail gracefully and render the image with whatever params it supports.