### PR TITLE
Fix config for custom CloudFormation Outputs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "scripts": {
     "test": "jest",
-    "docs": "serve ./docs",
-    "build": "sls package",
-    "deploy": "sls deploy"
+    "docs": "serve ./docs"
   },
   "version": "2.0.6",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "test": "jest",
-    "docs": "serve ./docs"
+    "docs": "serve ./docs",
+    "build": "sls package",
+    "deploy": "sls deploy"
   },
   "version": "2.0.6",
   "private": false,

--- a/serverless.yml
+++ b/serverless.yml
@@ -77,6 +77,10 @@ resources:
       Properties:
         DomainName: '${self:custom.settings.environment.CUSTOM_DOMAIN}'
         ValidationMethod: DNS
+  Outputs:
+    CloudFrontDistributionOutput:
+      Value:
+        'Fn::GetAtt': [ CloudFrontDistribution, DomainName ]
 functions:
   index:
     package:
@@ -98,10 +102,6 @@ functions:
           method: get
           contentHandling: CONVERT_TO_BINARY
     environment: ${self:custom.settings.environment}
-Outputs:
-  CloudFrontDistributionOutput:
-    Value:
-      'Fn::GetAtt': [ CloudFrontDistribution, DomainName ]
 custom:
   empty: ''
   settingsFilePath: ${opt:settings,'./settings.yml'}


### PR DESCRIPTION
### The Bug
The `Outputs` section for custom CloudFormation resources is incorrectly placed at the root level of `serverless.yml` therefore it is always ignored prior to this PR.

Steps to reproduce the behavior:
1. Do an `sls package`.
2. Look for the string "CloudFrontDistributionOutput" in the generated `.serverless/cloudformation-template-update-stack.json`. You won't find that string. That's the bug.

The `CloudFrontDistributionOutput` object should be there so it will be deployed as part of the CloudFormation stack.

### The Fix

This PR fixes that problem by simply moving `Outputs` inside `resources`.

Steps to verify fix:
1. Do an `sls package`.
2. Look for the string "CloudFrontDistributionOutput" in the generated `.serverless/cloudformation-template-update-stack.json`. You can now find it as `Outputs.CloudFrontDistributionOutput`.